### PR TITLE
Overhaul smoke test skip/fail decision logic

### DIFF
--- a/.github/workflows/run-workspace-smoke-tests.yaml
+++ b/.github/workflows/run-workspace-smoke-tests.yaml
@@ -105,7 +105,7 @@ jobs:
           set -e
           for i in $(seq 1 10); do
             if curl -fsS http://localhost:7007/health >/dev/null; then
-              echo "RHDH is ready"; exit 0; fi
+              echo "RHDH is ready"; sleep 10; exit 0; fi
             echo "Waiting for RHDH... (Attempt ${i}/10)"
             # Check if container is still running
             if ! docker ps | grep -q rhdh; then
@@ -117,11 +117,12 @@ jobs:
           echo "RHDH did not become ready in time."
           exit 1
 
-      - name: List installed plugins
-        run: docker exec rhdh ls -l /opt/app-root/src/dynamic-plugins-root
-
-      - name: Print generated dynamic plugins config
-        run: docker exec rhdh cat /opt/app-root/src/dynamic-plugins-root/app-config.dynamic-plugins.yaml
+      - name: Print container debug info
+        run: |
+          echo "===== Installed plugins"
+          docker exec rhdh ls -l /opt/app-root/src/dynamic-plugins-root
+          echo "===== Generated dynamic plugins config"
+          docker exec rhdh cat /opt/app-root/src/dynamic-plugins-root/app-config.dynamic-plugins.yaml
 
       - name: Verify plugin loading
         id: collect-results
@@ -134,43 +135,53 @@ jobs:
             echo "failed-plugins<<EOF" >> "$GITHUB_OUTPUT"
             echo "(no-plugins)" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
-            exit 0
+            exit 1
           fi
-          LOGS=$(docker logs rhdh || true)
+          LOGS=$(docker logs rhdh 2>&1 || true)
           failures=()
-          echo "===== Checking logs for plugin loaded messages"
+
+          # Verify backstage startup
+          if ! echo "$LOGS" | grep -qiE "backstage info.*listening on"; then
+            echo "ERROR: Backstage startup message not found in logs"
+            failures+=("(backstage-not-started)")
+          fi
+
+          # Verify each plugin loaded
           for plugin in $PLUGINS; do
-            echo "Asserting plugin loaded: $plugin"
-            # Match either the unpack path or the canonical "loaded dynamic ... plugin '<pkg>' from" message
-            if echo "$LOGS" | grep -qiE "loaded dynamic .* plugin .*${plugin}(-dynamic)?'" ; then
-              echo "Plugin loaded: $plugin"
+            if echo "$LOGS" | grep -qiE "loaded dynamic .* plugin .*${plugin}(-dynamic)?'"; then
+              echo "  OK: $plugin"
             else
               echo "Plugin NOT loaded: $plugin"
               failures+=("$plugin")
             fi
           done
-          if echo "$LOGS" | grep -E "(InstallException|Error while adding OCI plugin|Failed to load dynamic plugin|dynamic plugin.*error)" >/dev/null; then
-            echo "Detected dynamic plugin loading errors in logs"
+
+          # Check for plugin loading errors
+          if echo "$LOGS" | grep -qE "(InstallException|Error while adding OCI plugin|Failed to load dynamic plugin|dynamic plugin.*error)"; then
             failures+=("(log-errors)")
           fi
+
+          # Check for plugin initialization errors
+          while IFS= read -r line; do
+            plugin_name=$(echo "$line" | sed "s/.*Plugin '\([^']*\)'.*/\1/")
+            echo "  INIT ERROR: $plugin_name"
+            failures+=("$plugin_name (init-error)")
+          done < <(echo "$LOGS" | grep -oE "Unhandled rejection Plugin '[^']+' startup failed" || true)
+
+          # Write outputs and exit
           if [ ${#failures[@]} -eq 0 ]; then
             echo "success=true" >> "$GITHUB_OUTPUT"
             echo "failed-plugins<<EOF" >> "$GITHUB_OUTPUT"
-            echo "" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
           else
             echo "success=false" >> "$GITHUB_OUTPUT"
             echo "failed-plugins<<EOF" >> "$GITHUB_OUTPUT"
             printf "%s\n" "${failures[@]}" >> "$GITHUB_OUTPUT"
             echo "EOF" >> "$GITHUB_OUTPUT"
+            printf "\nThese plugins failed to load to RHDH:\n"
+            printf "%s\n" "${failures[@]}"
+            exit 1
           fi
-
-      - name: Fail if any plugin failed to load
-        if: ${{ steps.collect-results.outputs.success != 'true' }}
-        run: |
-          echo "The following plugins failed to load to RHDH:"
-          echo "${{ steps.collect-results.outputs.failed-plugins }}"
-          exit 1
 
       - name: Capture error logs
         if: always()
@@ -185,21 +196,18 @@ jobs:
           fi
           
           LOGS=$(docker logs rhdh 2>&1 || echo "Failed to retrieve logs")
-          
-          # Extract errors from logs with short context 
-          ERROR_LINES=$(echo "$LOGS" | grep -iE -B 2 -A 2 "(error|exception|failed|failure|installException)" | grep -vE "(no errors|successfully|resolved|fixed)" | grep -v "^--$" | tail -n 100 || echo "")
-          
+          ERROR_LINES=$(echo "$LOGS" | grep -E "(backstage error|InstallException|Unhandled rejection|Failed to load dynamic plugin|Error while adding OCI plugin)" || true)
           echo "error-logs<<EOF" >> "$GITHUB_OUTPUT"
-          if [ -n "$ERROR_LINES" ] && [ "$ERROR_LINES" != "" ]; then
+          if [ -n "$ERROR_LINES" ]; then
             echo "$ERROR_LINES" >> "$GITHUB_OUTPUT"
           else
-            echo "No specific error patterns found in container logs. Check full workflow logs for details." >> "$GITHUB_OUTPUT"
+            echo "No error patterns found in container logs. Check full workflow logs for details." >> "$GITHUB_OUTPUT"
           fi
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Print container logs
         if: always()
-        run: docker logs rhdh || true
+        run: docker logs rhdh 2>&1 || true
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/workspace-tests.yaml
+++ b/.github/workflows/workspace-tests.yaml
@@ -127,6 +127,7 @@ jobs:
     outputs:
       plugins-metadata-complete: ${{ steps.build-dynamic-plugins.outputs.plugins-metadata-complete }}
       skip-tests-missing-env: ${{ steps.build-dynamic-plugins.outputs.skip-tests-missing-env }}
+      failure-reason: ${{ steps.build-dynamic-plugins.outputs.failure-reason }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -146,11 +147,13 @@ jobs:
           TOTAL_PLUGINS=0
           PLUGINS_METADATA_COMPLETE="false"
           SKIP_TESTS_MISSING_ENV="false"
+          FAILURE_REASON=""
 
           if [ -z "$PUBLISHED_EXPORTS" ]; then
             echo "No published exports provided."
             echo "plugins-metadata-complete=$PLUGINS_METADATA_COMPLETE" >> "$GITHUB_OUTPUT"
             echo "skip-tests-missing-env=$SKIP_TESTS_MISSING_ENV" >> "$GITHUB_OUTPUT"
+            echo "failure-reason=$FAILURE_REASON" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -241,6 +244,8 @@ jobs:
                   done <<< "$ENV_VARS"
                   
                   if [ ${#MISSING_ENVS[@]} -gt 0 ]; then
+                    FAILURE_REASON="Missing required environment variables in $WORKSPACE_ENV_FILE for plugin $PLUGIN_NAME: ${MISSING_ENVS[*]}"
+                    echo "failure-reason=$FAILURE_REASON" >> "$GITHUB_OUTPUT"
                     echo "  ::error::Environment variables missing from test.env: ${MISSING_ENVS[*]}"
                     echo "  Config for $PLUGIN_NAME references these environment variables but they are not defined in $WORKSPACE_ENV_FILE."
                     exit 1
@@ -277,6 +282,7 @@ jobs:
 
           echo "plugins-metadata-complete=$PLUGINS_METADATA_COMPLETE" >> "$GITHUB_OUTPUT"
           echo "skip-tests-missing-env=$SKIP_TESTS_MISSING_ENV" >> "$GITHUB_OUTPUT"
+          echo "failure-reason=$FAILURE_REASON" >> "$GITHUB_OUTPUT"
 
       - name: Upload smoke test artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -295,7 +301,7 @@ jobs:
       target-branch: ${{ needs.resolve.outputs.target-branch }}
 
   add-skipped-test-comment:
-    if: ${{ always() && needs.resolve.outputs.pr-number != 'null' && needs.resolve.outputs.pr-number != '' && (needs.resolve.outputs.workspace == '' || (needs.prepare-test-config.result != 'skipped' && (needs.prepare-test-config.outputs.plugins-metadata-complete != 'true' || needs.prepare-test-config.outputs.skip-tests-missing-env == 'true'))) }}
+    if: ${{ always() && needs.resolve.outputs.pr-number != 'null' && needs.resolve.outputs.pr-number != '' && (needs.resolve.outputs.workspace == '' || (needs.prepare-test-config.result == 'success' && (needs.prepare-test-config.outputs.plugins-metadata-complete != 'true' || needs.prepare-test-config.outputs.skip-tests-missing-env == 'true'))) }}
     needs:
       - resolve
       - prepare-test-config
@@ -366,8 +372,60 @@ jobs:
               .addRaw('\n### Tests Skipped\n\n' + summaryDetail)
               .write();
 
+  add-prepare-failure-comment:
+    if: ${{ always() && needs.resolve.outputs.pr-number != 'null' && needs.resolve.outputs.pr-number != '' && needs.resolve.outputs.workspace != '' && needs.prepare-test-config.result == 'failure' }}
+    needs:
+      - resolve
+      - prepare-test-config
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      statuses: write
+    steps:
+      - name: Report preparation failure
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          OVERLAY_COMMIT: ${{ needs.resolve.outputs.overlay-commit }}
+          INPUT_PR_NUMBER: ${{ needs.resolve.outputs.pr-number }}
+          INPUT_PREPARE_FAILURE_REASON: ${{ needs.prepare-test-config.outputs.failure-reason || '' }}
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const overlayCommit = process.env.OVERLAY_COMMIT;
+            const pr = Number(core.getInput('pr_number') || '0');
+            const detailedReason = core.getInput('prepare_failure_reason');
+            const failureReason = detailedReason && detailedReason.trim().length > 0
+              ? detailedReason
+              : 'Smoke test workflow failed while preparing test configuration. Check workflow logs for details (for example, missing environment variables in workspace `smoke-tests/test.env`).';
+
+            if (overlayCommit) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: overlayCommit,
+                description: 'Smoke test preparation failed',
+                state: 'failure',
+                target_url: runUrl,
+                context: 'smoketest',
+              });
+            }
+
+            if (pr) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body: `:x: [Smoke test workflow](${runUrl}) failed during preparation.\n\n:warning: ${failureReason}`,
+              });
+            }
+
+            await core.summary
+              .addRaw('\n### Smoke Tests Preparation Failed\n\n' + failureReason)
+              .write();
+
   add-test-result-comment:
-    if: ${{ always() && needs.prepare-test-config.outputs.plugins-metadata-complete == 'true' && needs.prepare-test-config.outputs.skip-tests-missing-env != 'true' }}
+    if: ${{ always() && needs.prepare-test-config.result == 'success' && needs.run-smoke-tests.result != 'skipped' && needs.prepare-test-config.outputs.plugins-metadata-complete == 'true' && needs.prepare-test-config.outputs.skip-tests-missing-env != 'true' }}
     needs:
       - resolve
       - prepare-test-config


### PR DESCRIPTION
## Summary
- implement RHIDP-12283 by tightening docker smoke result checks to fail on missing startup signal and dynamic plugin startup/load error patterns
- implement RHIDP-12381 by separating true skip paths from prepare-stage failures in `workspace-tests`, including a dedicated prepare-failure status/comment path
- preserve docker-based smoke execution flow and artifact contract while improving failure reason reporting (`failure-reason`) for missing env vars

## Test plan
- [x] Parse modified workflow YAML files with Python `yaml.safe_load`
- [x] Verify git diff scope is limited to `.github/workflows/workspace-tests.yaml` and `.github/workflows/run-workspace-smoke-tests.yaml`
- [x] Validate no whitespace/conflict issues with `git diff --check`
- [ ] Run publish/smoketest matrix on this PR

## Jira
- [RHIDP-12283](https://redhat.atlassian.net/browse/RHIDP-12283)
- [RHIDP-12381](https://redhat.atlassian.net/browse/RHIDP-12381)

Made with [Cursor](https://cursor.com)